### PR TITLE
Add homebrew cask installation method for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,16 @@ The original dashboard felt like working at NASA. 50 years ago. I hope this dash
 
 ### Install
 
-Download for Mac: [Webpack.Dashboard-1.0.0.dmg](https://github.com/FormidableLabs/electron-webpack-dashboard/releases/download/0.0.1-beta.1/Webpack.Dashboard-1.0.0.dmg)
+#### Mac
+Download the App for Mac: [Webpack.Dashboard-1.0.0.dmg](https://github.com/FormidableLabs/electron-webpack-dashboard/releases/download/0.0.1-beta.1/Webpack.Dashboard-1.0.0.dmg)
 
+Or you can also install the App via [Homebrew Cask](https://caskroom.github.io/):
+
+```bash
+$ brew cask install webpack-dashboard
+```
+
+#### Windows
 Download for Windows: [Webpack.Dashboard.Setup.1.0.0.exe](https://github.com/FormidableLabs/electron-webpack-dashboard/releases/download/0.0.1-beta.1/Webpack.Dashboard.Setup.1.0.0.exe)
 
 ### Configuring Your Project


### PR DESCRIPTION
Hello!

I recently created a new formulae for installing "Webpack Dashboard" (see caskroom/homebrew-cask#37744) using homebrew-cask on a mac. It would be cool if we can add this to the README documentation.

Best regards,
Pascal