### PR TITLE
fix(distribution): Set macOS app category

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
       "main.prod.js.map",
       "package.json"
     ],
+    "mac": {
+      "category": "public.app-category.developer-tools"
+    },
     "dmg": {
       "contents": [
         {
@@ -125,7 +128,7 @@
     "cross-spawn": "^5.1.0",
     "css-loader": "^0.28.3",
     "electron": "^1.6.10",
-    "electron-builder": "^19.8.0",
+    "electron-builder": "^19.22.1",
     "electron-devtools-installer": "^2.2.0",
     "enzyme": "^2.9.1",
     "enzyme-to-json": "^1.5.1",


### PR DESCRIPTION
Set category to `public.app-category.developer-tools`. Since electron-builder 19.22.1 mac.category is also used to automatically compute category for Linux. So, even if you don't plan to publish this awesome app to AppStore, you need to set category to be sure that on some Linux your app will be not in the `Lost and found` (https://github.com/electron-userland/electron-builder/releases/tag/v19.22.1).

BTW, feel free to contact me directly in case of any electron-builder questions/problems :)