### PR TITLE
feat: Register the app as handler for protocol "x-webpack-dashboard"

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -17,6 +17,8 @@ import isDev from 'electron-is-dev';
 
 import MenuBuilder from './menu';
 
+const webpackProtocolSchema = 'x-webpack-dashboard';
+
 if (process.env.NODE_ENV === 'production') {
   const sourceMapSupport = require('source-map-support');
   sourceMapSupport.install();
@@ -152,6 +154,16 @@ const startApp = () => {
       title: 'New Dashboard',
       description: 'Connect to a new Webpack Dashboard instance'
     }]);
+  }
+
+  /**
+   * Set up app to open when the user calls a URI
+   * with the protocol "x-webpack-dashboard://".
+   * This way, the client webpack script can open
+   * this app programmatically
+   */
+  if (process.env.NODE_ENV === 'production') {
+    app.setAsDefaultProtocolClient(webpackProtocolSchema);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -80,7 +80,15 @@
     },
     "publish": {
       "provider": "github"
-    }
+    },
+    "protocols": [
+      {
+        "name": "Webpack Dashboard URL",
+        "schemes": [
+          "x-webpack-dashboard"
+        ]
+      }
+    ]
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
With a custom protocol, we can open the app programmatically from the webpack client script, as requested in issue #27

The following code could be used to open the app from the client script:

```js
// npm i --save-dev opn
const opn = require('opn');
opn("x-webpack-dashboard://open-please");
// you could also use childProcess.spawn()
```

In the future, you could parse options from the URL, like the application port, or integrate with the Dashboard plugin.

Tested on Windows. Don´t have access to a MacOS, but should work.