### PR TITLE
Fixed format-versions when problem bundle does not contain the versions

### DIFF
--- a/app/util/format-versions.js
+++ b/app/util/format-versions.js
@@ -17,13 +17,11 @@ const template = Handlebars.compile(
 );
 
 const formatVersions = function (versions) {
-  return (
-    (versions.versions.length &&
-      template({
-        versions: versions.versions,
-      })) ||
-    ''
-  );
-}
+  if (!versions || !versions.versions || !versions.versions.length) return ''
+
+  return template({
+    versions: versions.versions
+  });
+};
 
 module.exports = formatVersions;

--- a/test/unit/app/util/format-versions.spec.js
+++ b/test/unit/app/util/format-versions.spec.js
@@ -1,0 +1,46 @@
+/* eslint no-use-before-define: off */
+import chalk from 'chalk';
+
+import formatVersions from '../../../../app/util/format-versions';
+
+describe('formatVersions', () => {
+  it('should handle versions being undefined correctly', () => {
+    expect(formatVersions(undefined)).toBe('');
+  });
+
+  it('should handle versions.version being undefined correctly', () => {
+    expect(formatVersions({ versions: undefined })).toBe('');
+  });
+
+  it('should handle versions.version being empty array', () => {
+    expect(formatVersions({ versions: [] })).toBe('');
+  });
+
+  it('should handle versions.version being set with correct values', () => {
+    const expected = `${chalk.yellow(chalk.underline('Version skews'))}
+
+webpack:
+  a:
+      - Abc
+`;
+
+    expect(formatVersions(correctVersionsFixture())).toEqual(expected);
+  });
+});
+
+const Problem = {
+  toString() {
+    return 'Abc'
+  }
+}
+
+const correctVersionsFixture = () => ({
+  versions: [
+    {
+      name: 'webpack',
+      versions: {
+        a: Problem,
+      }
+    }
+  ]
+});


### PR DESCRIPTION
It appears that it's possible the problem bundle received from webpack does
not contain the `versions` data at all. This was not handled correctly in
the `formatVersions` function.

Fixed the function to be more robust and added unit tests for it along the
way. Unit tests for an existing case was added but really not sure if it's
the right format as I never seen it :)

**Note** I disabled `no-use-before-define` in my unit test as I found it
makes tests much more readable. Don't hesitate to disapprove and I'll
revert the change.