### PR TITLE
correctly show problems by changing flex 0 to flex 1

### DIFF
--- a/app/containers/problems.js
+++ b/app/containers/problems.js
@@ -13,7 +13,7 @@ import { ScrollerBase } from '../components/scroller-base';
 const fadeInAnimation = keyframes`${fadeIn}`;
 
 const ProblemContainer = withSettings(styled(ScrollerBase)`
-  flex: 0;
+  flex: 1;
   white-space: pre-wrap;
   font-family: 'menloregular';
   font-size: ${({ fontSizeModifier }) => getFontSize(11, fontSizeModifier)}px;


### PR DESCRIPTION
Resolves #56 

Before:

<img width="437" alt="screen shot 2018-01-31 at 16 59 44" src="https://user-images.githubusercontent.com/6714912/35655734-3bce8a0a-06a8-11e8-99ce-2d53f2667bb3.png">

After:

<img width="433" alt="screen shot 2018-01-31 at 16 58 04" src="https://user-images.githubusercontent.com/6714912/35655739-42457042-06a8-11e8-85fd-99fa3305f421.png">
